### PR TITLE
perf(core): getType uses a cache for well known types.

### DIFF
--- a/src/core/util/props.js
+++ b/src/core/util/props.js
@@ -187,9 +187,26 @@ const functionTypeCheckRE = /^\s*function (\w+)/
  * because a simple equality check will fail when running
  * across different vms / iframes.
  */
-function getType (fn) {
+function getTypeName (fn) {
   const match = fn && fn.toString().match(functionTypeCheckRE)
   return match ? match[1] : ''
+}
+
+/**
+ * Build a cache for known types.
+ * We could build it dynamically, but since array are sometime requested,
+ * it fill up the cache for nothing.
+ * Type list is taken from https://vuejs.org/v2/guide/components-props.html#Type-Checks
+ */
+const TYPE_CACHE = new Map(
+  [String, Number, Boolean, Array, Object, Date, Function, Symbol, null, undefined].map(fn => [fn, getTypeName(fn)]))
+
+function getType (fn) {
+  const cached = TYPE_CACHE.get(fn)
+  if (cached !== undefined) {
+    return cached
+  }
+  return getTypeName(fn)
 }
 
 function isSameType (a, b) {


### PR DESCRIPTION
getType is called a lot, and it just run the same regexp over and over on the same base types.
A cache increase its own efficiency by more than 80% for basic types. On a real world application with a lot of components, getType was profiled for 8% of call duration before this patch, and about 0.5% after.
The impact is more limited for smaller applications.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `main` branch for v2.x (or to a previous version branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
